### PR TITLE
Add tqosi.com

### DIFF
--- a/lib/spam_email/blacklist.rb
+++ b/lib/spam_email/blacklist.rb
@@ -2098,6 +2098,7 @@ module SpamEmail
       'topranklist.de',
       'tormail.org',
       'tqoai.com',
+      'tqosi.com',
       'tradedoubling.co.uk',
       'tradermail.info',
       'tralalajos.ga',


### PR DESCRIPTION
Another domain used by https://10minutemail.net/.