### PR TITLE
Remove virgilio.it

### DIFF
--- a/lib/spam_email/blacklist.rb
+++ b/lib/spam_email/blacklist.rb
@@ -3805,7 +3805,7 @@ module SpamEmail
       'vipmail.pw',
       'virgilio.ga',
       'virgilio.gq',
-      'virgilio.it',
+      # 'virgilio.it',
       'virgilio.ml',
       'virgiliomail.cf',
       'virgiliomail.ga',


### PR DESCRIPTION
This is not a trash email site: https://en.wikipedia.org/wiki/Virgilio.it

Was added in https://github.com/phillipp/spam_email/commit/b4f299e1ed562f359e55bb2f5e13d47e6a93316b. We have at least one paying customer with such an address.