### PR TITLE
Don't block mail.ru

### DIFF
--- a/lib/spam_email/blacklist.rb
+++ b/lib/spam_email/blacklist.rb
@@ -3883,7 +3883,7 @@ module SpamEmail
       'mail.ludovicdu12.me',
       'mail.mezimages.net',
       'mail.myspamnoturs.cf',
-      'mail.ru',
+      # 'mail.ru',
       'mail.wtf',
       'mail.zp.ua',
       'mail0.cf',

--- a/lib/spam_email/version.rb
+++ b/lib/spam_email/version.rb
@@ -1,3 +1,3 @@
 module SpamEmail
-  VERSION = '0.0.59'
+  VERSION = '0.0.60'
 end


### PR DESCRIPTION
mail.ru is a [real Russian company](https://en.wikipedia.org/wiki/Mail.Ru).

We at sofatutor have over 100 paying customers with such an email address, which were regarded as frauds after the last update. The domain was added here: https://github.com/phillipp/spam_email/pull/85/files#diff-d5788ba9b61f912544fb1022591c7de2R3886.

For now, we need a quick fix. We should also take care not to block legit email domains in the future.