### PR TITLE
Add dns lookup to check for email domain aliases.

### DIFF
--- a/lib/spam_email/check.rb
+++ b/lib/spam_email/check.rb
@@ -9,7 +9,7 @@ module SpamEmail
 
     complete_domain = address.domain.downcase
     main_domain = PublicSuffix.domain(complete_domain)
-    mx_complete_domain = Resolv::DNS.new.getresources(complete_domain, Resolv::DNS::Resource::IN::MX)[0].exchange.to_s
+    mx_complete_domain = Resolv::DNS.new.getresources(complete_domain, Resolv::DNS::Resource::IN::MX).first&.exchange.to_s
     mx_main_domain = PublicSuffix.domain(mx_complete_domain)
 
     (BLACKLIST & [complete_domain, main_domain, mx_complete_domain, mx_main_domain]).any?


### PR DESCRIPTION
This should help to make the blacklist more valuable.

**Context:**
Trash mailers provide email aliases that are mapped to a different domain. Using resolv to get to the original MX record helps to catch more email addresses that coming from trash mailer.