### PR TITLE
<< is deprecated, we should be using .add

### DIFF
--- a/lib/spam_email.rb
+++ b/lib/spam_email.rb
@@ -10,7 +10,7 @@ class SpamEmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     if SpamEmail.blacklisted?(value)
       message = (options[:message] || I18n.t(:blacklisted, scope: 'spam_email.validations.email'))
-      record.errors[attribute] << message
+      record.errors.add(attribute, :blacklist, message: message)
     end
   end
 end

--- a/spec/spam_email_validator_spec.rb
+++ b/spec/spam_email_validator_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 describe SpamEmailValidator do
   record_class = Class.new do
     include ActiveModel::Validations
+
+    def self.model_name
+      ActiveModel::Name.new(self, nil, "temp_record")
+    end
+
     attr_accessor :email
     validates :email, :spam_email => true
   end


### PR DESCRIPTION
As specified in the ActiveModel::Errors class using `<<` is deprecated, we should be using g`.add` instead.

https://github.com/rails/rails/blob/6-1-stable/activemodel/lib/active_model/errors.rb#L645-L651

I added the `model_name` method so the specs would pass, it is trying to resolve `model_name` somewhere, and fails b/c it's an anonymous class. 